### PR TITLE
Fix ccDirect

### DIFF
--- a/loader/source/main.c
+++ b/loader/source/main.c
@@ -220,6 +220,11 @@ static void app_loadgameconfig(u8 *tempgameconf, u32 tempgameconfsize)
 	if(patchOnce)
 		return;
 
+	// initialize memory to 0
+	vu32* CCdirect = (vu32*)0x932F009C;
+	*CCdirect = 0;
+	DCFlushRange((void*)CCdirect, 0x4);
+
 	u32 ret;
 	s32 gameidmatch, maxgameidmatch = -1, maxgameidmatch2 = -1;
 	u32 i, parsebufpos;
@@ -531,9 +536,8 @@ static void app_loadgameconfig(u8 *tempgameconf, u32 tempgameconfsize)
 							// Direct button mapping, less confusing
 							if(codeval > 0) {
 								//set mem2 bool
-								vu32* CCdirect = (vu32*)0x932F009C;
 								*CCdirect = 1;
-								DCFlushRange((void*)0x932F009C, 0x4);
+								DCFlushRange((void*)CCdirect, 0x4);
 							}
 						}
 					}

--- a/loader/source/main.c
+++ b/loader/source/main.c
@@ -531,8 +531,9 @@ static void app_loadgameconfig(u8 *tempgameconf, u32 tempgameconfsize)
 							// Direct button mapping, less confusing
 							if(codeval > 0) {
 								//set mem2 bool
-								vu32* CCdirect = (vu32*)0x93003074;
+								vu32* CCdirect = (vu32*)0x932F009C;
 								*CCdirect = 1;
+								DCFlushRange((void*)0x932F009C, 0x4);
 							}
 						}
 					}

--- a/loader/source/ppc/PADReadGC.c
+++ b/loader/source/ppc/PADReadGC.c
@@ -1562,7 +1562,7 @@ u32 _start(u32 calledByGame)
 		if(BTPad[chan].used & (C_CC | C_CCP))
 		{
 			// Input cannot be changed during gameplay, it's just bad design.
-			if(*CCDirect == 1)
+			if(*CCDirect)
 			{
 				if(BTPad[chan].button & BT_BUTTON_A)
 					button |= PAD_BUTTON_A;

--- a/loader/source/ppc/PADReadGC.c
+++ b/loader/source/ppc/PADReadGC.c
@@ -1562,7 +1562,7 @@ u32 _start(u32 calledByGame)
 		if(BTPad[chan].used & (C_CC | C_CCP))
 		{
 			// Input cannot be changed during gameplay, it's just bad design.
-			if(*CCDirect)
+			if(*CCDirect == 1)
 			{
 				if(BTPad[chan].button & BT_BUTTON_A)
 					button |= PAD_BUTTON_A;

--- a/loader/source/ppc/PADReadGC.c
+++ b/loader/source/ppc/PADReadGC.c
@@ -65,6 +65,7 @@ static vu32* isSMC       = (vu32*)0x802AD6D0; //constant value to determine game
 //static u8 forcePlayer = 0; // invalid value, so it first picks a free slot
 static vu32* P1force = (vu32*)0x932F0094;
 static vu32* wiiPort = (vu32*)0x932F0098;
+static vu32* CCDirect = (vu32*)0x932F009C;
 
 static vu32* PADIsBarrel = (vu32*)0xD3003130;
 static vu32* PADBarrelEnabled = (vu32*)0xD3003140;
@@ -78,7 +79,6 @@ static vu32* PADSwitchRequired = (vu32*)0x93003064;
 static vu32* PADForceConnected = (vu32*)0x93003068;
 static vu32* drcAddress = (vu32*)0x9300306C;
 static vu32* drcAddressAligned = (vu32*)0x93003070;
-static vu32* CCDirect = (vu32*)0x93003074;
 
 static u32 PrevAdapterChannel1 = 0;
 static u32 PrevAdapterChannel2 = 0;


### PR DESCRIPTION
This PR changes the memory address of the value for `ccDirect` so it's adjacent to the values for `wiiChan`, and adds a `DCFlushRange` call similar to the one that `wiiChan` uses. These two changes together were enough to get `ccDirect` working on my Wii U. (Before these changes, the setting had no effect.)